### PR TITLE
fix: use a `a` element instead of a `button`

### DIFF
--- a/src/routes/dash/[course]/+page.svelte
+++ b/src/routes/dash/[course]/+page.svelte
@@ -47,9 +47,7 @@
 				</h1>
 			</div>
 			<div class="navbar-end">
-				<button class="btn btn-square btn-ghost" title="Indietro" on:click={() => history.back()}>
-					⬆️
-				</button>
+				<a class="btn btn-square btn-ghost" title="Indietro" href="/"> ⬆️ </a>
 			</div>
 		</nav>
 
@@ -75,7 +73,10 @@
 								{/if}
 							</a>
 							{#if teaching.telegram}
-								<a href="https://t.me/{teaching.telegram}" class="text-center text-lg join-item border-l-2">👥</a>
+								<a
+									href="https://t.me/{teaching.telegram}"
+									class="text-center text-lg join-item border-l-2">👥</a
+								>
 							{/if}
 						</li>
 					{/each}


### PR DESCRIPTION
Improves accessibility. We don't need to go back every time as we're just one level under the root logically.