### PR TITLE
fix(rebrand): add missing title in `[course]/page.svelte`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "dynamik",
+	"name": "risorse",
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "risorse",
+	"name": "dynamik",
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,8 +18,10 @@
 
 <div class="flex justify-center">
 	<div class="container max-w-5xl">
-		<h1 class="text-4xl m-10 font-semibold text-center">Benvenuto su CSUnibo!</h1>
-
+		<div class="m-10">
+			<h1 class="text-4xl font-semibold text-center">Risorse</h1>
+			<h3 class="text-2 font-semibold text-center">Raccolte di materiali per lo studio da CSUnibo</h3>
+		</div>
 		<ul class="menu p-2 text-lg">
 			{#each data.courses as course}
 				<Line name={course.name} icon={course.icon} href="{base}/dash/{course.id}" />

--- a/src/routes/[...dir]/[zfile=dir]/+page.svelte
+++ b/src/routes/[...dir]/[zfile=dir]/+page.svelte
@@ -89,7 +89,7 @@
 </script>
 
 <svelte:head>
-	<title>Dynamik | {urlParts[urlParts.length - 1]}</title>
+	<title>Risorse | {urlParts[urlParts.length - 1]}</title>
 </svelte:head>
 
 <svelte:body on:keydown={keydown} />

--- a/src/routes/[...dir]/[zfile=dir]/+page.svelte
+++ b/src/routes/[...dir]/[zfile=dir]/+page.svelte
@@ -99,7 +99,7 @@
 		<div class="navbar-center">
 			<div class="lg:text-lg breadcrumbs text-sm">
 				<ul>
-					<li>🏠<a class="ml-1" href="/">Dynamik</a></li>
+					<li>🏠<a class="ml-1" href="/">Risorse</a></li>
 					{#each urlParts as part}
 						{@const href = getPartHref(part)}
 						<li><a {href}>{part}</a></li>


### PR DESCRIPTION
Mi è venuto il dubbio che però nel `page.svelte` dedicato all'insegnamento forse nel `title` è più corretto mettere il nome dell'insegnamento?