### PR TITLE
fix(style): join border-color match

### DIFF
--- a/src/routes/dash/[course]/ListTeaching.svelte
+++ b/src/routes/dash/[course]/ListTeaching.svelte
@@ -27,8 +27,9 @@
 								{teaching.name ? teaching.name : teaching.url}
 							</a>
 							{#if teaching.chat != null && teaching.chat !== ''}
-								<a href="https://{teaching.chat}" class="text-center text-lg join-item border-base-content border-l-2"
-									>👥</a
+								<a
+									href="https://{teaching.chat}"
+									class="text-center text-lg join-item border-base-content border-l-2">👥</a
 								>
 							{/if}
 						</li>

--- a/src/routes/dash/[course]/ListTeaching.svelte
+++ b/src/routes/dash/[course]/ListTeaching.svelte
@@ -27,7 +27,7 @@
 								{teaching.name ? teaching.name : teaching.url}
 							</a>
 							{#if teaching.chat != null && teaching.chat !== ''}
-								<a href="https://{teaching.chat}" class="text-center text-lg join-item border-l-2"
+								<a href="https://{teaching.chat}" class="text-center text-lg join-item border-base-content border-l-2"
 									>👥</a
 								>
 							{/if}


### PR DESCRIPTION
Ora il bordo dell' `<li>` matcha con anche il bordo join, prima con il tema chiaro si vedeva proprio la riga bianca invece di quella scura.