### PR TITLE
feat: using csunibo.github.io from statik data.url

### DIFF
--- a/src/lib/components/Line.svelte
+++ b/src/lib/components/Line.svelte
@@ -14,7 +14,7 @@
 
 	/**
 	 * Check if the statik url for the data uses an external link to 'csunibo.github.io'
-	 * 
+	 *
 	 * This function is especially created for '/libri/'.
 	 */
 	function checkBaseUrl() {
@@ -23,7 +23,7 @@
 		}
 		return true;
 	}
-	
+
 	let isSpinning = false;
 	async function downloadFile() {
 		isSpinning = true;
@@ -88,7 +88,9 @@
 				<span class="flex icon-[solar--folder-bold] text-xl mr-2" style="color: #FDE74C"></span>
 				<a
 					class="flex link link-hover sm:flex-wrap text-primary"
-					href={checkBaseUrl() ? base + '/' + data.name + '?' + $page.url.searchParams : data.url + '?' + $page.url.searchParams}
+					href={checkBaseUrl()
+						? base + '/' + data.name + '?' + $page.url.searchParams
+						: data.url + '?' + $page.url.searchParams}
 				>
 					{data.name}
 				</a>

--- a/src/lib/components/Line.svelte
+++ b/src/lib/components/Line.svelte
@@ -7,11 +7,23 @@
 
 	export let data: File | Directory;
 	export let customUrl: string | undefined = undefined;
-	$: base = $page.url.pathname.split('?')[0];
 
+	$: base = $page.url.pathname.split('?')[0];
 	$: isFile = 'mime' in data;
 	$: external = 'mime' in data ? data.mime === 'text/statik-link' : false;
 
+	/**
+	 * Check if the statik url for the data uses an external link to 'csunibo.github.io'
+	 * 
+	 * This function is especially created for '/libri/'.
+	 */
+	function checkBaseUrl() {
+		if (data.url.startsWith('https://csunibo.github.io')) {
+			return false;
+		}
+		return true;
+	}
+	
 	let isSpinning = false;
 	async function downloadFile() {
 		isSpinning = true;
@@ -76,7 +88,7 @@
 				<span class="flex icon-[solar--folder-bold] text-xl mr-2" style="color: #FDE74C"></span>
 				<a
 					class="flex link link-hover sm:flex-wrap text-primary"
-					href={customUrl ?? base + '/' + data.name + '?' + $page.url.searchParams}
+					href={checkBaseUrl() ? base + '/' + data.name + '?' + $page.url.searchParams : data.url + '?' + $page.url.searchParams}
 				>
 					{data.name}
 				</a>

--- a/src/lib/components/Line.svelte
+++ b/src/lib/components/Line.svelte
@@ -6,7 +6,7 @@
 	import { getDoneStatus } from '$lib/todo-file';
 
 	export let data: File | Directory;
-	export let customUrl: string | undefined = undefined;
+	// export let customUrl: string | undefined = undefined;
 
 	$: base = $page.url.pathname.split('?')[0];
 	$: isFile = 'mime' in data;

--- a/src/lib/components/Line.svelte
+++ b/src/lib/components/Line.svelte
@@ -17,7 +17,7 @@
 	 *
 	 * This function is especially created for '/libri/'.
 	 */
-	function checkBaseUrl() {
+	function isUsingExternalBase(data) {
 		if (data.url.startsWith('https://csunibo.github.io')) {
 			return false;
 		}
@@ -88,7 +88,7 @@
 				<span class="flex icon-[solar--folder-bold] text-xl mr-2" style="color: #FDE74C"></span>
 				<a
 					class="flex link link-hover sm:flex-wrap text-primary"
-					href={checkBaseUrl()
+					href={isUsingExternalBase(data)
 						? base + '/' + data.name + '?' + $page.url.searchParams
 						: data.url + '?' + $page.url.searchParams}
 				>

--- a/src/lib/components/Line.svelte
+++ b/src/lib/components/Line.svelte
@@ -17,7 +17,7 @@
 	 *
 	 * This function is especially created for '/libri/'.
 	 */
-	function isUsingExternalBase(data) {
+	function isUsingExternalBase(data: File | Directory) {
 		if (data.url.startsWith('https://csunibo.github.io')) {
 			return false;
 		}


### PR DESCRIPTION
In pratica per accontentare la prof di Algebra e Geometria la sua dir `/libri/` verrà redirectata su _csunibo.github.io_ (il vecchio statik) per non avere url basati su unibo.it -.-

Quindi in generale per tutti i data.url che su statik saranno assegnati sotto il dominio _csunibo.github.io_ verranno redirectati lì.

Thanks to @samuelemusiani per questa incredibile avventura 