### PR TITLE
Fix download

### DIFF
--- a/src/lib/components/Line.svelte
+++ b/src/lib/components/Line.svelte
@@ -4,6 +4,7 @@
 	import type { File, Directory } from '$lib/api';
 	import { formatDate } from '$lib/date';
 	import { getDoneStatus } from '$lib/todo-file';
+	import { GH_PAGES_BASE_URL } from '$lib/const';
 
 	export let data: File | Directory;
 	// export let customUrl: string | undefined = undefined;
@@ -18,27 +19,10 @@
 	 * This function is especially created for '/libri/'.
 	 */
 	function isUsingExternalBase(data: File | Directory) {
-		if (data.url.startsWith('https://csunibo.github.io')) {
+		if (data.url.startsWith(GH_PAGES_BASE_URL)) {
 			return false;
 		}
 		return true;
-	}
-
-	let isSpinning = false;
-	async function downloadFile() {
-		isSpinning = true;
-		const url = data.url;
-		const response = await fetch(url);
-		const blob = await response.blob();
-		const urlObject = window.URL.createObjectURL(new Blob([blob]));
-		const a = document.createElement('a');
-		a.href = urlObject;
-		a.download = data.name;
-		document.body.appendChild(a);
-		a.click();
-		a.remove();
-		isSpinning = false;
-		URL.revokeObjectURL(urlObject);
 	}
 
 	$: isDone = getDoneStatus(data.url);
@@ -101,15 +85,16 @@
 			{#if isFile}
 				{isFile && data.size != '0 B' ? data.size : '-'}
 				{#if data.size != '0 B'}
-					<button class="flex text-lg ml-3" on:click={downloadFile}>
-						<span
-							class="text-accent text-3xl {isSpinning
-								? 'icon-[eos-icons--loading]'
-								: 'icon-[solar--download-square-bold]'}"
-						></span>
-					</button>
+					<a
+						class="flex text-lg ml-3"
+						href={GH_PAGES_BASE_URL + base + '/' + data.name}
+						download
+						target="_blank"
+					>
+						<span class="text-accent text-3xl icon-[solar--download-square-bold]"></span>
+					</a>
 				{:else}
-					<button disabled class="flex text-lg ml-3" on:click={downloadFile}>
+					<button disabled class="flex text-lg ml-3">
 						<span class="text-neutral text-3xl icon-[solar--download-square-bold]"></span>
 					</button>
 				{/if}

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,6 +1,6 @@
 const ORG = 'csunibo';
 export const RISORSE_BASE_URL =
-	process.env.VITE_RISORSE_BASE_URL || 'https://risorse.students.cs.unibo.it';
+  process.env.VITE_RISORSE_BASE_URL || 'https://risorse.students.cs.unibo.it';
 export const GH_PAGES_BASE_URL = `https://${ORG}.github.io`;
 const GH_BASE_URL = `https://github.com/${ORG}`;
 const GH_DEV_BASE_URL = `https://github.dev/${ORG}`;
@@ -8,13 +8,13 @@ export const STATIK_URL = (path: string) => `${GH_PAGES_BASE_URL}/${path}/statik
 export const ASSET_URL = (path: string) => `${GH_PAGES_BASE_URL}/${path}`;
 export const FUZZY_URL = (path: string) => `${GH_PAGES_BASE_URL}/${path}/fuzzy.json`;
 export const EDIT_URLS = (path: string) => {
-	const [, repo, ...rest] = path.split('/');
-	const filePath = rest.join('/');
-	return {
-		github: `${GH_BASE_URL}/${repo}/blob/main/${filePath}`,
-		github_repo: `${GH_BASE_URL}/${repo}`,
-		github_edit: `${GH_BASE_URL}/${repo}/edit/main/${filePath}`,
-		github_dev: `${GH_DEV_BASE_URL}/${repo}/blob/main/${filePath}`
-	};
+  const [, repo, ...rest] = path.split('/');
+  const filePath = rest.join('/');
+  return {
+    github: `${GH_BASE_URL}/${repo}/blob/main/${filePath}`,
+    github_repo: `${GH_BASE_URL}/${repo}`,
+    github_edit: `${GH_BASE_URL}/${repo}/edit/main/${filePath}`,
+    github_dev: `${GH_DEV_BASE_URL}/${repo}/blob/main/${filePath}`
+  };
 };
 export const MAX_YEARS_FOR_DEGREE = 3;

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,6 +1,6 @@
 const ORG = 'csunibo';
 export const RISORSE_BASE_URL =
-  process.env.VITE_RISORSE_BASE_URL || 'https://risorse.students.cs.unibo.it';
+	process.env.VITE_RISORSE_BASE_URL || 'https://risorse.students.cs.unibo.it';
 export const GH_PAGES_BASE_URL = `https://${ORG}.github.io`;
 const GH_BASE_URL = `https://github.com/${ORG}`;
 const GH_DEV_BASE_URL = `https://github.dev/${ORG}`;
@@ -8,13 +8,13 @@ export const STATIK_URL = (path: string) => `${GH_PAGES_BASE_URL}/${path}/statik
 export const ASSET_URL = (path: string) => `${GH_PAGES_BASE_URL}/${path}`;
 export const FUZZY_URL = (path: string) => `${GH_PAGES_BASE_URL}/${path}/fuzzy.json`;
 export const EDIT_URLS = (path: string) => {
-  const [, repo, ...rest] = path.split('/');
-  const filePath = rest.join('/');
-  return {
-    github: `${GH_BASE_URL}/${repo}/blob/main/${filePath}`,
-    github_repo: `${GH_BASE_URL}/${repo}`,
-    github_edit: `${GH_BASE_URL}/${repo}/edit/main/${filePath}`,
-    github_dev: `${GH_DEV_BASE_URL}/${repo}/blob/main/${filePath}`
-  };
+	const [, repo, ...rest] = path.split('/');
+	const filePath = rest.join('/');
+	return {
+		github: `${GH_BASE_URL}/${repo}/blob/main/${filePath}`,
+		github_repo: `${GH_BASE_URL}/${repo}`,
+		github_edit: `${GH_BASE_URL}/${repo}/edit/main/${filePath}`,
+		github_dev: `${GH_DEV_BASE_URL}/${repo}/blob/main/${filePath}`
+	};
 };
 export const MAX_YEARS_FOR_DEGREE = 3;


### PR DESCRIPTION
Per risolvere #189. Tutti i file che sono visualizzabili (es. i pdf) il browser li aprirà comunque e ci facciamo poco. Però almeno file strani vengono scaricati come dio vuole. Inoltre non ci sono più qui bug orribili che scarica un html con dentro il link del file che si voleva scaricare. Direi che risolviamo un po' di problemi e semplifichiamo il tutto.

L'unica cosa non ho capito se su safari l'attributo `download` sul tag `<a>` è supportato, perché alcuni dicono di sì altri dicono di no. Non ho safari per provare