### PR TITLE
fix: location not found in FuzzySearch if rendered via SSR

### DIFF
--- a/src/routes/[...dir]/[zfile=dir]/FuzzySearch.svelte
+++ b/src/routes/[...dir]/[zfile=dir]/FuzzySearch.svelte
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <script lang="ts">
 	import { base } from '$app/paths';
+	import { browser } from '$app/environment';
+
 	import type { Fuzzy, FuzzyFile } from '$lib/api';
 	import Fuse from 'fuse.js';
 
@@ -37,7 +39,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			return result.url;
 		}
 
-		return base + new URL(result.url, location.origin).pathname;
+		// SSR-safe: no `location` on the server
+		const origin = browser ? window.location.origin : 'http://localhost';
+
+		return base + new URL(result.url, origin).pathname;
 	}
 
 	function keydown(e: KeyboardEvent) {


### PR DESCRIPTION
2c91581 introduced something that now the FuzzySearch component is rendered on the server (SSR) and if we try to access a direct link the `location` is undefined and we get a 500. If we start from the main page everything works fine.

For example: https://risorse.vercel.app/analisi-matematica?from=informatica